### PR TITLE
server: add main service logic

### DIFF
--- a/dist/examples/request-body.json
+++ b/dist/examples/request-body.json
@@ -1,0 +1,6 @@
+{
+  "client_params": {
+    "group": "workers",
+    "node_uuid": "c988d250-9fdf-4cdc-bed3-9037c56406fb"
+  }
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -1,8 +1,14 @@
 package cli
 
 import (
+	"errors"
+	"fmt"
+	"net/http"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/coreos/airlock/internal/server"
 )
 
 var (
@@ -12,6 +18,7 @@ var (
 	}
 )
 
+// runServe runs the main HTTP service
 func runServe(cmd *cobra.Command, cmdArgs []string) error {
 	logrus.WithFields(logrus.Fields{
 		"groups": runSettings.LockGroups,
@@ -21,6 +28,19 @@ func runServe(cmd *cobra.Command, cmdArgs []string) error {
 		"address": runSettings.ServiceAddress,
 		"port":    runSettings.ServicePort,
 	}).Info("starting service")
+
+	if runSettings == nil {
+		return errors.New("nil runSettings")
+	}
+	airlock := server.Airlock{*runSettings}
+
+	http.Handle(server.PreRebootEndpoint, airlock.PreReboot())
+	http.Handle(server.SteadyStateEndpoint, airlock.SteadyState())
+
+	listenAddr := fmt.Sprintf("%s:%d", runSettings.ServiceAddress, runSettings.ServicePort)
+	if err := http.ListenAndServe(listenAddr, nil); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/server/airlock.go
+++ b/internal/server/airlock.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"errors"
+
+	"github.com/coreos/airlock/internal/config"
+)
+
+var (
+	// errNilAirlockServer is returned on nil server
+	errNilAirlockServer = errors.New("nil Airlock server")
+)
+
+// Airlock is the main service
+type Airlock struct {
+	config.Settings
+}

--- a/internal/server/http_params.go
+++ b/internal/server/http_params.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+// HTTPParams contains all parameters for a remote lock request.
+type HTTPParams struct {
+	ClientParams Params `json:"client_params"`
+}
+
+// Params contains client parameters for a remote lock request.
+type Params struct {
+	NodeUUID string `json:"node_uuid"`
+	Group    string `json:"group"`
+}
+
+// NodeIdentity contains validated client identity from request parameters.
+type NodeIdentity struct {
+	UUID  string
+	Group string
+}
+
+// validateIdentity validates client request and parameters, returning its identity
+func validateIdentity(req *http.Request) (*NodeIdentity, error) {
+	var group string
+	var nodeID string
+
+	if req.Header.Get("fleet-reboot") != "true" {
+		return nil, errors.New("wrong 'fleet-reboot' header")
+	}
+
+	decoder := json.NewDecoder(req.Body)
+	var input HTTPParams
+	if err := decoder.Decode(&input); err != nil {
+		return nil, err
+	}
+
+	if input.ClientParams.Group == "" {
+		return nil, errors.New("empty group")
+	}
+	group = input.ClientParams.Group
+
+	if input.ClientParams.NodeUUID == "" {
+		return nil, errors.New("empty node ID")
+	}
+	nodeID = input.ClientParams.NodeUUID
+
+	identity := NodeIdentity{
+		Group: group,
+		UUID:  nodeID,
+	}
+
+	return &identity, nil
+}

--- a/internal/server/pre_reboot.go
+++ b/internal/server/pre_reboot.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/coreos/airlock/internal/lock"
+)
+
+const (
+	// PreRebootEndpoint is the endpoint for requesting a semaphore lock.
+	PreRebootEndpoint = "/v1/pre-reboot"
+)
+
+// PreReboot is the handler for the `/v1/pre-reboot` endpoint.
+func (a *Airlock) PreReboot() http.Handler {
+	handler := func(w http.ResponseWriter, req *http.Request) {
+		logrus.Debug("got pre-reboot request")
+		if a == nil {
+			http.Error(w, errNilAirlockServer.Error(), 500)
+			return
+		}
+
+		nodeIdentity, err := validateIdentity(req)
+		if err != nil {
+			logrus.Errorln("failed to validate client identity: ", err)
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		logrus.WithFields(logrus.Fields{
+			"group": nodeIdentity.Group,
+			"uuid":  nodeIdentity.UUID,
+		}).Debug("processing client pre-reboot request")
+
+		slots, ok := a.LockGroups[nodeIdentity.Group]
+		if !ok {
+			err := fmt.Errorf("unknown group %q", nodeIdentity.Group)
+			logrus.Errorln("unable to satisfy client request: ", err)
+			http.Error(w, err.Error(), 400)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), a.EtcdTxnTimeout)
+		defer cancel()
+		lockManager, err := lock.NewManager(ctx, a.EtcdEndpoints, nodeIdentity.Group, slots)
+		if err != nil {
+			logrus.Errorln("failed to initialize semaphore manager: ", err)
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		defer lockManager.Close()
+
+		err = lockManager.RecursiveLock(ctx, nodeIdentity.UUID)
+		if err != nil {
+			logrus.Errorln(err)
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		logrus.WithFields(logrus.Fields{
+			"group": nodeIdentity.Group,
+			"uuid":  nodeIdentity.UUID,
+		}).Debug("givin green-flag to pre-reboot request")
+	}
+
+	return http.HandlerFunc(handler)
+}

--- a/internal/server/steady_state.go
+++ b/internal/server/steady_state.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/coreos/airlock/internal/lock"
+)
+
+const (
+	// SteadyStateEndpoint is the endpoint for releasing a semaphore lock.
+	SteadyStateEndpoint = "/v1/steady-state"
+)
+
+// SteadyState is the handler for the `/v1/steady-state` endpoint.
+func (a *Airlock) SteadyState() http.Handler {
+	handler := func(w http.ResponseWriter, req *http.Request) {
+		logrus.Debug("got steady-state report")
+		if a == nil {
+			http.Error(w, errNilAirlockServer.Error(), 500)
+			return
+		}
+
+		nodeIdentity, err := validateIdentity(req)
+		if err != nil {
+			logrus.Errorln("failed to validate client identity: ", err)
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		logrus.WithFields(logrus.Fields{
+			"group": nodeIdentity.Group,
+			"uuid":  nodeIdentity.UUID,
+		}).Debug("processing client steady-state report")
+
+		slots, ok := a.LockGroups[nodeIdentity.Group]
+		if !ok {
+			err := fmt.Errorf("unknown group %q", nodeIdentity.Group)
+			logrus.Errorln("unable to satisfy client request: ", err)
+			http.Error(w, err.Error(), 400)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), a.EtcdTxnTimeout)
+		defer cancel()
+		lockManager, err := lock.NewManager(ctx, a.EtcdEndpoints, nodeIdentity.Group, slots)
+		if err != nil {
+			logrus.Errorln("failed to initialize semaphore manager: ", err)
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		defer lockManager.Close()
+
+		err = lockManager.UnlockIfHeld(ctx, nodeIdentity.UUID)
+		if err != nil {
+			logrus.Errorln("failed to release any semaphore lock: ", err)
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		logrus.WithFields(logrus.Fields{
+			"group": nodeIdentity.Group,
+			"uuid":  nodeIdentity.UUID,
+		}).Debug("steady-state confirmed")
+	}
+
+	return http.HandlerFunc(handler)
+}


### PR DESCRIPTION
This adds the core logic for the main service, following the protocol specified in https://github.com/coreos/airlock/pull/1.