### PR TITLE
docs: add reference and examples for container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Airlock
 
+[![Build status](https://travis-ci.org/coreos/airlock.svg?branch=master)](https://travis-ci.org/coreos/airlock)
+[![Container image](https://quay.io/repository/coreos/airlock/status)](https://quay.io/repository/coreos/airlock)
+
 Airlock is a minimal update/reboot manager for clusters of Linux nodes. It is meant to be simple to run in a container.
 
 Fleet-wide updates and reboots are coordinated via semaphore locking, with configurable groups and simultaneous reboot slots.
@@ -13,3 +16,9 @@ go get -u -v github.com/coreos/airlock && airlock serve --help
 ```
 
 A TOML configuration sample (with comments) is available under [examples](dist/examples/).
+
+An automatically built `x86_64` container image is available on [quay.io](https://quay.io/repository/coreos/airlock) and can be run as:
+
+```
+docker run -p 3333:3333/tcp -v "$PWD/dist/examples/config.toml:/etc/airlock/config.toml" quay.io/coreos/airlock:master airlock serve -vv
+```


### PR DESCRIPTION
This links to and adds a docker command example for the autobuilt
`quay.io/coreos/airlock:master` container image.