### PR TITLE
config: explicitly opt-out TLS

### DIFF
--- a/dist/examples/config.toml
+++ b/dist/examples/config.toml
@@ -2,6 +2,7 @@
 [service]
 address = "127.0.0.1"
 port = 3333
+tls = false
 
 # Etcd-v3 client configuration
 [etcd3]

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"time"
 )
 
@@ -8,6 +9,7 @@ import (
 type Settings struct {
 	ServiceAddress string
 	ServicePort    uint64
+	ServiceTLS     bool
 
 	EtcdEndpoints  []string
 	EtcdTxnTimeout time.Duration
@@ -29,6 +31,9 @@ func Parse(fpath string) (Settings, error) {
 	if len(settings.LockGroups) == 0 {
 		settings.LockGroups["default"] = 1
 	}
+	if settings.ServiceTLS {
+		return Settings{}, errors.New("TLS mode not yet implemented")
+	}
 
 	return settings, nil
 }
@@ -38,6 +43,7 @@ func defaultSettings() Settings {
 	return Settings{
 		ServiceAddress: "0.0.0.0",
 		ServicePort:    9090,
+		ServiceTLS:     true,
 
 		EtcdEndpoints:  []string{},
 		EtcdTxnTimeout: time.Duration(3) * time.Second,

--- a/internal/config/toml.go
+++ b/internal/config/toml.go
@@ -17,6 +17,7 @@ type tomlConfig struct {
 type serviceSection struct {
 	Address *string `toml:"address"`
 	Port    *uint64 `toml:"port"`
+	TLS     *bool   `toml:"tls"`
 }
 
 // etcd3Section holds the optional `etcd3` fragment
@@ -77,6 +78,9 @@ func mergeService(settings *Settings, cfg serviceSection) {
 	}
 	if cfg.Port != nil {
 		settings.ServicePort = *cfg.Port
+	}
+	if cfg.TLS != nil {
+		settings.ServiceTLS = *cfg.TLS
 	}
 }
 


### PR DESCRIPTION
While this doesn't implement TLS for now, users should
assume TLS is the default mode and opt-out in config.