### PR TITLE
server: serialize errors as JSON

### DIFF
--- a/internal/herrors/herrors.go
+++ b/internal/herrors/herrors.go
@@ -1,0 +1,58 @@
+package herrors
+
+import (
+	"encoding/json"
+)
+
+// HTTPError is the error type used by the main HTTP service.
+type HTTPError struct {
+	// Code is the HTTP code to return.
+	Code int `json:"-"`
+	// Kind is a machine-friendly error description.
+	Kind string `json:"kind"`
+	// Value is a human-friendly error description.
+	Value string `json:"value"`
+}
+
+// New builds a new HTTPError.
+func New(code int, kind string, value string) HTTPError {
+	outKind := kind
+	if outKind == "" {
+		outKind = "generic_error"
+	}
+
+	outValue := value
+	if outValue == "" {
+		outValue = "generic error"
+	}
+
+	return HTTPError{
+		Code:  code,
+		Kind:  outKind,
+		Value: outValue,
+	}
+
+}
+
+// FromError converts an error.
+func FromError(err error) HTTPError {
+	outValue := err.Error()
+	if outValue == "" {
+		outValue = "generic error"
+	}
+
+	return HTTPError{
+		Code:  500,
+		Kind:  "generic_error",
+		Value: outValue,
+	}
+}
+
+// ToJSON converts an error to JSON.
+func (herr HTTPError) ToJSON() string {
+	out, err := json.Marshal(herr)
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}

--- a/internal/herrors/herrors_test.go
+++ b/internal/herrors/herrors_test.go
@@ -1,0 +1,14 @@
+package herrors
+
+import (
+	"testing"
+)
+
+func TestJSON(t *testing.T) {
+	herr := New(500, "generic_kind", "generic value")
+	out := herr.ToJSON()
+	expected := "{\"kind\":\"generic_kind\",\"value\":\"generic value\"}"
+	if out != expected {
+		t.Errorf("unexpected JSON: %s", out)
+	}
+}

--- a/internal/server/airlock.go
+++ b/internal/server/airlock.go
@@ -1,14 +1,13 @@
 package server
 
 import (
-	"errors"
-
 	"github.com/coreos/airlock/internal/config"
+	"github.com/coreos/airlock/internal/herrors"
 )
 
 var (
 	// errNilAirlockServer is returned on nil server
-	errNilAirlockServer = errors.New("nil Airlock server")
+	errNilAirlockServer = herrors.New(500, "nil_server", "nil Airlock server")
 )
 
 // Airlock is the main service

--- a/internal/server/steady_state.go
+++ b/internal/server/steady_state.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"github.com/coreos/airlock/internal/herrors"
 	"github.com/coreos/airlock/internal/lock"
 )
 
@@ -28,11 +29,10 @@ func (a *Airlock) SteadyState() http.Handler {
 	prometheus.MustRegister(steadyStateIncomingReqs)
 
 	handler := func(w http.ResponseWriter, req *http.Request) {
-		code, err := a.steadyStateHandler(req)
-		if err != nil {
-			http.Error(w, err.Error(), code)
+		if herr := a.preRebootHandler(req); herr != nil {
+			http.Error(w, herr.ToJSON(), herr.Code)
 		} else {
-			w.WriteHeader(code)
+			w.WriteHeader(http.StatusOK)
 		}
 	}
 
@@ -40,18 +40,20 @@ func (a *Airlock) SteadyState() http.Handler {
 }
 
 // steadyStateHandler contains logic to handle steady-state.
-func (a *Airlock) steadyStateHandler(req *http.Request) (int, error) {
+func (a *Airlock) steadyStateHandler(req *http.Request) *herrors.HTTPError {
 	steadyStateIncomingReqs.Inc()
 	logrus.Debug("got steady-state report")
 
 	if a == nil {
-		return 500, errNilAirlockServer
+		return &errNilAirlockServer
 	}
 
 	nodeIdentity, err := validateIdentity(req)
 	if err != nil {
-		logrus.Errorln("failed to validate client identity: ", err)
-		return 400, err
+		msg := fmt.Sprintf("failed to validate client identity: %s", err.Error())
+		logrus.Errorln(msg)
+		herr := herrors.New(400, "invalid_client_identity", msg)
+		return &herr
 	}
 	logrus.WithFields(logrus.Fields{
 		"group": nodeIdentity.Group,
@@ -60,24 +62,29 @@ func (a *Airlock) steadyStateHandler(req *http.Request) (int, error) {
 
 	slots, ok := a.LockGroups[nodeIdentity.Group]
 	if !ok {
-		err := fmt.Errorf("unknown group %q", nodeIdentity.Group)
-		logrus.Errorln("unable to satisfy client request: ", err)
-		return 400, err
+		msg := fmt.Sprintf("unknown group %q", nodeIdentity.Group)
+		logrus.Errorln(msg)
+		herr := herrors.New(400, "unknown_group", msg)
+		return &herr
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), a.EtcdTxnTimeout)
 	defer cancel()
 	lockManager, err := lock.NewManager(ctx, a.EtcdEndpoints, nodeIdentity.Group, slots)
 	if err != nil {
-		logrus.Errorln("failed to initialize semaphore manager: ", err)
-		return 500, err
+		msg := fmt.Sprintf("failed to initialize semaphore manager: %s", err.Error())
+		logrus.Errorln(msg)
+		herr := herrors.New(500, "failed_sem_init", msg)
+		return &herr
 	}
 	defer lockManager.Close()
 
 	err = lockManager.UnlockIfHeld(ctx, nodeIdentity.UUID)
 	if err != nil {
-		logrus.Errorln("failed to release any semaphore lock: ", err)
-		return 500, err
+		msg := fmt.Sprintf("failed to release any semaphore lock: %s", err.Error())
+		logrus.Errorln(msg)
+		herr := herrors.New(500, "failed_lock", err.Error())
+		return &herr
 	}
 
 	logrus.WithFields(logrus.Fields{
@@ -85,5 +92,5 @@ func (a *Airlock) steadyStateHandler(req *http.Request) (int, error) {
 		"uuid":  nodeIdentity.UUID,
 	}).Debug("steady-state confirmed")
 
-	return http.StatusOK, nil
+	return nil
 }


### PR DESCRIPTION
This unifies error handling on all HTTP endpoints in order to return
uniform JSON structures. Those provide both a machine-friendly
short "kind" and a human-friendly detailed "value".