### PR TITLE
server/steady_state: fix wrong handler

### DIFF
--- a/internal/server/steady_state.go
+++ b/internal/server/steady_state.go
@@ -29,7 +29,7 @@ func (a *Airlock) SteadyState() http.Handler {
 	prometheus.MustRegister(steadyStateIncomingReqs)
 
 	handler := func(w http.ResponseWriter, req *http.Request) {
-		if herr := a.preRebootHandler(req); herr != nil {
+		if herr := a.steadyStateHandler(req); herr != nil {
 			http.Error(w, herr.ToJSON(), herr.Code)
 		} else {
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This fixes a logic regression in steady_state handler introduced
by mistake by the error serialization rework in https://github.com/coreos/airlock/pull/17.