### PR TITLE
server: add db metrics to handlers

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -8,13 +8,10 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/coreos/airlock/internal/lock"
 	"github.com/coreos/airlock/internal/server"
 	"github.com/coreos/airlock/internal/status"
 )
@@ -24,15 +21,6 @@ var (
 		Use:  "serve",
 		RunE: runServe,
 	}
-
-	configGroups = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "airlock_config_groups",
-		Help: "Total number of configured groups.",
-	})
-	configSlots = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "airlock_config_semaphore_slots",
-		Help: "Total number of configured slots per group.",
-	}, []string{"group"})
 )
 
 // runServe runs the main HTTP service
@@ -90,7 +78,7 @@ func runServe(cmd *cobra.Command, cmdArgs []string) error {
 	// Background consistency checker.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go checkConsistency(ctx, airlock)
+	go airlock.RunConsistencyChecker(ctx)
 
 	<-stopCh
 	return nil
@@ -104,74 +92,4 @@ func runService(stopCh chan os.Signal, service http.Server, airlock server.Airlo
 		}).Error("service failure")
 	}
 	stopCh <- os.Interrupt
-}
-
-// checkConsistency continuously checks for consistency between configuration and remote state.
-//
-// It takes care of polling etcd, exposing the shared state as metrics, and warning if
-// it detects a mismatch with the service configuration.
-func checkConsistency(ctx context.Context, service server.Airlock) {
-	prometheus.MustRegister(configGroups)
-	prometheus.MustRegister(configSlots)
-
-	configGroups.Set(float64(len(service.LockGroups)))
-	for group, maxSlots := range service.LockGroups {
-		configSlots.WithLabelValues(group).Set(float64(maxSlots))
-	}
-
-	// Consistency-checking logic, with its own scope for defers.
-	checkAndLog := func() {
-		for group, maxSlots := range service.LockGroups {
-			innerCtx, cancel := context.WithTimeout(ctx, service.EtcdTxnTimeout)
-			defer cancel()
-
-			// TODO(lucab): re-arrange so that the manager can be re-used.
-			manager, err := lock.NewManager(innerCtx, service.EtcdEndpoints, group, maxSlots)
-			if err != nil {
-				logrus.WithFields(logrus.Fields{
-					"reason": err.Error(),
-				}).Warn("consistency check, manager creation failed")
-				continue
-			}
-			semaphore, err := manager.FetchSemaphore(innerCtx)
-			if err != nil {
-				logrus.WithFields(logrus.Fields{
-					"reason": err.Error(),
-				}).Warn("consistency check, semaphore fetch failed")
-				continue
-			}
-
-			// Update metrics.
-			server.DatabaseLocksGauge.WithLabelValues(group).Set(float64(len(semaphore.Holders)))
-			server.DatabaseSlotsGauge.WithLabelValues(group).Set(float64(semaphore.TotalSlots))
-
-			// Log any inconsistencies.
-			if semaphore.TotalSlots != maxSlots {
-				logrus.WithFields(logrus.Fields{
-					"config":   maxSlots,
-					"database": semaphore.TotalSlots,
-					"group":    group,
-				}).Warn("semaphore max slots consistency check failed")
-			}
-			if semaphore.TotalSlots < uint64(len(semaphore.Holders)) {
-				logrus.WithFields(logrus.Fields{
-					"group":  group,
-					"holder": len(semaphore.Holders),
-					"slots":  semaphore.TotalSlots,
-				}).Warn("semaphore locks consistency check failed")
-			}
-		}
-	}
-
-	for {
-		checkAndLog()
-
-		pause := time.NewTimer(time.Minute)
-		select {
-		case <-ctx.Done():
-			break
-		case <-pause.C:
-			continue
-		}
-	}
 }

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -48,45 +48,45 @@ func NewManager(ctx context.Context, etcdURLs []string, group string, slots uint
 //
 // It will return an error if there is a problem getting or setting the
 // semaphore, or if the maximum number of holders has been reached.
-func (m *Manager) RecursiveLock(ctx context.Context, id string) error {
+func (m *Manager) RecursiveLock(ctx context.Context, id string) (*Semaphore, error) {
 	sem, version, err := m.get(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	held, err := sem.RecursiveLock(id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if held {
-		return nil
+		return sem, nil
 	}
 
 	if err := m.set(ctx, sem, version); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return sem, nil
 }
 
 // UnlockIfHeld removes this lock `id` as a holder of the semaphore
 //
 // It returns an error if there is a problem getting or setting the semaphore.
-func (m *Manager) UnlockIfHeld(ctx context.Context, id string) error {
+func (m *Manager) UnlockIfHeld(ctx context.Context, id string) (*Semaphore, error) {
 	sem, version, err := m.get(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := sem.UnlockIfHeld(id); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := m.set(ctx, sem, version); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return sem, nil
 }
 
 // FetchSemaphore fetches current semaphore version

--- a/internal/server/airlock.go
+++ b/internal/server/airlock.go
@@ -1,23 +1,39 @@
 package server
 
 import (
+	"context"
+	"errors"
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/coreos/airlock/internal/config"
 	"github.com/coreos/airlock/internal/herrors"
+	"github.com/coreos/airlock/internal/lock"
 )
 
 var (
 	// errNilAirlockServer is returned on nil server
 	errNilAirlockServer = herrors.New(500, "nil_server", "nil Airlock server")
 
-	// DatabaseLocksGauge holds a metrics gauge with per-group lock-holders status.
-	DatabaseLocksGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	// configGroupsGauge holds a metrics gauge with number of configured groups.
+	configGroupsGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "airlock_config_groups",
+		Help: "Total number of configured groups.",
+	})
+	// configSlotsGauge holds a metrics gauge with per-group configured slots.
+	configSlotsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "airlock_config_semaphore_slots",
+		Help: "Total number of configured slots per group.",
+	}, []string{"group"})
+	// databaseLocksGauge holds a metrics gauge with per-group lock-holders status.
+	databaseLocksGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "airlock_database_semaphore_lock_holders",
 		Help: "Total number of locked slots per group, in the database.",
 	}, []string{"group"})
-	// DatabaseSlotsGauge holds a metrics gauge with per-group slots limit.
-	DatabaseSlotsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	// databaseSlotsGauge holds a metrics gauge with per-group slots limit.
+	databaseSlotsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "airlock_database_semaphore_slots",
 		Help: "Total number of slots per group, in the database.",
 	}, []string{"group"})
@@ -30,10 +46,92 @@ type Airlock struct {
 
 // RegisterMetrics registers all server-related metrics.
 func (a *Airlock) RegisterMetrics() error {
-	for _, collector := range []prometheus.Collector{DatabaseLocksGauge, DatabaseSlotsGauge} {
+	if a == nil {
+		return errors.New("nil Airlock")
+	}
+
+	collectors := []prometheus.Collector{
+		configGroupsGauge,
+		configSlotsGauge,
+		databaseLocksGauge,
+		databaseSlotsGauge,
+	}
+	for _, collector := range collectors {
 		if err := prometheus.Register(collector); err != nil {
 			return err
 		}
 	}
+
+	configGroupsGauge.Set(float64(len(a.LockGroups)))
+	for group, maxSlots := range a.LockGroups {
+		configSlotsGauge.WithLabelValues(group).Set(float64(maxSlots))
+	}
+
 	return nil
+}
+
+// RunConsistencyChecker runs a continuous checker for consistency between configuration
+// and remote state.
+func (a *Airlock) RunConsistencyChecker(ctx context.Context) {
+	for {
+		for group, maxSlots := range a.LockGroups {
+			a.checkConsistency(ctx, group, maxSlots)
+		}
+
+		pause := time.NewTimer(time.Minute)
+		select {
+		case <-ctx.Done():
+			break
+		case <-pause.C:
+			continue
+		}
+	}
+}
+
+// checkConsistencytakes takes care of polling etcd, exposing the shared state as metrics,
+// and warning if it detects a mismatch with the service configuration.
+func (a *Airlock) checkConsistency(ctx context.Context, group string, maxSlots uint64) {
+	if a == nil {
+		logrus.Error("consistency check, nil Airlock")
+		return
+	}
+
+	innerCtx, cancel := context.WithTimeout(ctx, a.EtcdTxnTimeout)
+	defer cancel()
+
+	// TODO(lucab): re-arrange so that the manager can be re-used.
+	manager, err := lock.NewManager(innerCtx, a.EtcdEndpoints, group, maxSlots)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"reason": err.Error(),
+		}).Warn("consistency check, manager creation failed")
+		return
+	}
+	semaphore, err := manager.FetchSemaphore(innerCtx)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"reason": err.Error(),
+		}).Warn("consistency check, semaphore fetch failed")
+		return
+	}
+
+	// Update metrics.
+	databaseLocksGauge.WithLabelValues(group).Set(float64(len(semaphore.Holders)))
+	databaseSlotsGauge.WithLabelValues(group).Set(float64(semaphore.TotalSlots))
+
+	// Log any inconsistencies.
+	if semaphore.TotalSlots != maxSlots {
+		logrus.WithFields(logrus.Fields{
+			"config":   maxSlots,
+			"database": semaphore.TotalSlots,
+			"group":    group,
+		}).Warn("semaphore max slots consistency check failed")
+	}
+	if semaphore.TotalSlots < uint64(len(semaphore.Holders)) {
+		logrus.WithFields(logrus.Fields{
+			"group":  group,
+			"holder": len(semaphore.Holders),
+			"slots":  semaphore.TotalSlots,
+		}).Warn("semaphore locks consistency check failed")
+	}
 }

--- a/internal/server/airlock.go
+++ b/internal/server/airlock.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/coreos/airlock/internal/config"
 	"github.com/coreos/airlock/internal/herrors"
 )
@@ -8,9 +10,30 @@ import (
 var (
 	// errNilAirlockServer is returned on nil server
 	errNilAirlockServer = herrors.New(500, "nil_server", "nil Airlock server")
+
+	// DatabaseLocksGauge holds a metrics gauge with per-group lock-holders status.
+	DatabaseLocksGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "airlock_database_semaphore_lock_holders",
+		Help: "Total number of locked slots per group, in the database.",
+	}, []string{"group"})
+	// DatabaseSlotsGauge holds a metrics gauge with per-group slots limit.
+	DatabaseSlotsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "airlock_database_semaphore_slots",
+		Help: "Total number of slots per group, in the database.",
+	}, []string{"group"})
 )
 
 // Airlock is the main service
 type Airlock struct {
 	config.Settings
+}
+
+// RegisterMetrics registers all server-related metrics.
+func (a *Airlock) RegisterMetrics() error {
+	for _, collector := range []prometheus.Collector{DatabaseLocksGauge, DatabaseSlotsGauge} {
+		if err := prometheus.Register(collector); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/server/pre_reboot.go
+++ b/internal/server/pre_reboot.go
@@ -88,8 +88,8 @@ func (a *Airlock) preRebootHandler(req *http.Request) *herrors.HTTPError {
 	}
 
 	// Update metrics.
-	DatabaseLocksGauge.WithLabelValues(nodeIdentity.Group).Set(float64(len(sem.Holders)))
-	DatabaseSlotsGauge.WithLabelValues(nodeIdentity.Group).Set(float64(sem.TotalSlots))
+	databaseLocksGauge.WithLabelValues(nodeIdentity.Group).Set(float64(len(sem.Holders)))
+	databaseSlotsGauge.WithLabelValues(nodeIdentity.Group).Set(float64(sem.TotalSlots))
 
 	logrus.WithFields(logrus.Fields{
 		"group": nodeIdentity.Group,

--- a/internal/server/pre_reboot.go
+++ b/internal/server/pre_reboot.go
@@ -79,13 +79,17 @@ func (a *Airlock) preRebootHandler(req *http.Request) *herrors.HTTPError {
 	}
 	defer lockManager.Close()
 
-	err = lockManager.RecursiveLock(ctx, nodeIdentity.UUID)
+	sem, err := lockManager.RecursiveLock(ctx, nodeIdentity.UUID)
 	if err != nil {
 		msg := fmt.Sprintf("failed to lock semaphore: %s", err.Error())
 		logrus.Errorln(msg)
 		herr := herrors.New(500, "failed_lock", err.Error())
 		return &herr
 	}
+
+	// Update metrics.
+	DatabaseLocksGauge.WithLabelValues(nodeIdentity.Group).Set(float64(len(sem.Holders)))
+	DatabaseSlotsGauge.WithLabelValues(nodeIdentity.Group).Set(float64(sem.TotalSlots))
 
 	logrus.WithFields(logrus.Fields{
 		"group": nodeIdentity.Group,

--- a/internal/server/steady_state.go
+++ b/internal/server/steady_state.go
@@ -88,8 +88,8 @@ func (a *Airlock) steadyStateHandler(req *http.Request) *herrors.HTTPError {
 	}
 
 	// Update metrics.
-	DatabaseLocksGauge.WithLabelValues(nodeIdentity.Group).Set(float64(len(sem.Holders)))
-	DatabaseSlotsGauge.WithLabelValues(nodeIdentity.Group).Set(float64(sem.TotalSlots))
+	databaseLocksGauge.WithLabelValues(nodeIdentity.Group).Set(float64(len(sem.Holders)))
+	databaseSlotsGauge.WithLabelValues(nodeIdentity.Group).Set(float64(sem.TotalSlots))
 
 	logrus.WithFields(logrus.Fields{
 		"group": nodeIdentity.Group,

--- a/internal/server/steady_state.go
+++ b/internal/server/steady_state.go
@@ -79,13 +79,17 @@ func (a *Airlock) steadyStateHandler(req *http.Request) *herrors.HTTPError {
 	}
 	defer lockManager.Close()
 
-	err = lockManager.UnlockIfHeld(ctx, nodeIdentity.UUID)
+	sem, err := lockManager.UnlockIfHeld(ctx, nodeIdentity.UUID)
 	if err != nil {
 		msg := fmt.Sprintf("failed to release any semaphore lock: %s", err.Error())
 		logrus.Errorln(msg)
 		herr := herrors.New(500, "failed_lock", err.Error())
 		return &herr
 	}
+
+	// Update metrics.
+	DatabaseLocksGauge.WithLabelValues(nodeIdentity.Group).Set(float64(len(sem.Holders)))
+	DatabaseSlotsGauge.WithLabelValues(nodeIdentity.Group).Set(float64(sem.TotalSlots))
 
 	logrus.WithFields(logrus.Fields{
 		"group": nodeIdentity.Group,


### PR DESCRIPTION
This improves the granularity of existing per-group metrics, by updating
metrics on each lock and unlock operation performed by the server.
It is meant to directly reflect current DB state in metrics, without
having to wait for the next run of the consistency checker.