### PR TITLE
server/http_params: relax client-ID semantics

### DIFF
--- a/dist/examples/request-body.json
+++ b/dist/examples/request-body.json
@@ -1,6 +1,6 @@
 {
   "client_params": {
     "group": "default",
-    "node_uuid": "c988d2509fdf5cdcbed39037c56406fb"
+    "id": "c988d2509fdf5cdcbed39037c56406fb"
   }
 }

--- a/internal/cli/ex-get-slots.go
+++ b/internal/cli/ex-get-slots.go
@@ -56,8 +56,8 @@ func printHumanShort(group string, semaphore *lock.Semaphore) {
 	fmt.Printf("group: %s\n", group)
 	fmt.Printf(" semaphore slots: %d\n", semaphore.TotalSlots)
 	fmt.Printf(" lock owners:\n")
-	for _, uuid := range semaphore.Holders {
-		fmt.Printf(" - %s\n", uuid)
+	for _, owner := range semaphore.Holders {
+		fmt.Printf(" - %s\n", owner)
 	}
 	fmt.Printf("\n---\n")
 }

--- a/internal/server/http_params.go
+++ b/internal/server/http_params.go
@@ -13,21 +13,18 @@ type HTTPParams struct {
 
 // Params contains client parameters for a remote lock request.
 type Params struct {
-	NodeUUID string `json:"node_uuid"`
-	Group    string `json:"group"`
+	Group string `json:"group"`
+	ID    string `json:"id"`
 }
 
 // NodeIdentity contains validated client identity from request parameters.
 type NodeIdentity struct {
-	UUID  string
 	Group string
+	ID    string
 }
 
 // validateIdentity validates client request and parameters, returning its identity
 func validateIdentity(req *http.Request) (*NodeIdentity, error) {
-	var group string
-	var nodeID string
-
 	if req.Header.Get("fleet-lock-protocol") != "true" {
 		return nil, errors.New("wrong 'fleet-lock-protocol' header")
 	}
@@ -39,18 +36,16 @@ func validateIdentity(req *http.Request) (*NodeIdentity, error) {
 	}
 
 	if input.ClientParams.Group == "" {
-		return nil, errors.New("empty group")
+		return nil, errors.New("empty client group")
 	}
-	group = input.ClientParams.Group
 
-	if input.ClientParams.NodeUUID == "" {
-		return nil, errors.New("empty node ID")
+	if input.ClientParams.ID == "" {
+		return nil, errors.New("empty client ID")
 	}
-	nodeID = input.ClientParams.NodeUUID
 
 	identity := NodeIdentity{
-		Group: group,
-		UUID:  nodeID,
+		Group: input.ClientParams.Group,
+		ID:    input.ClientParams.ID,
 	}
 
 	return &identity, nil

--- a/internal/server/pre_reboot.go
+++ b/internal/server/pre_reboot.go
@@ -57,7 +57,7 @@ func (a *Airlock) preRebootHandler(req *http.Request) *herrors.HTTPError {
 	}
 	logrus.WithFields(logrus.Fields{
 		"group": nodeIdentity.Group,
-		"uuid":  nodeIdentity.UUID,
+		"id":    nodeIdentity.ID,
 	}).Debug("processing client pre-reboot request")
 
 	slots, ok := a.LockGroups[nodeIdentity.Group]
@@ -79,7 +79,7 @@ func (a *Airlock) preRebootHandler(req *http.Request) *herrors.HTTPError {
 	}
 	defer lockManager.Close()
 
-	sem, err := lockManager.RecursiveLock(ctx, nodeIdentity.UUID)
+	sem, err := lockManager.RecursiveLock(ctx, nodeIdentity.ID)
 	if err != nil {
 		msg := fmt.Sprintf("failed to lock semaphore: %s", err.Error())
 		logrus.Errorln(msg)
@@ -93,7 +93,7 @@ func (a *Airlock) preRebootHandler(req *http.Request) *herrors.HTTPError {
 
 	logrus.WithFields(logrus.Fields{
 		"group": nodeIdentity.Group,
-		"uuid":  nodeIdentity.UUID,
+		"id":    nodeIdentity.ID,
 	}).Debug("givin green-flag to pre-reboot request")
 
 	return nil

--- a/internal/server/steady_state.go
+++ b/internal/server/steady_state.go
@@ -57,7 +57,7 @@ func (a *Airlock) steadyStateHandler(req *http.Request) *herrors.HTTPError {
 	}
 	logrus.WithFields(logrus.Fields{
 		"group": nodeIdentity.Group,
-		"uuid":  nodeIdentity.UUID,
+		"id":    nodeIdentity.ID,
 	}).Debug("processing client steady-state report")
 
 	slots, ok := a.LockGroups[nodeIdentity.Group]
@@ -79,7 +79,7 @@ func (a *Airlock) steadyStateHandler(req *http.Request) *herrors.HTTPError {
 	}
 	defer lockManager.Close()
 
-	sem, err := lockManager.UnlockIfHeld(ctx, nodeIdentity.UUID)
+	sem, err := lockManager.UnlockIfHeld(ctx, nodeIdentity.ID)
 	if err != nil {
 		msg := fmt.Sprintf("failed to release any semaphore lock: %s", err.Error())
 		logrus.Errorln(msg)
@@ -93,7 +93,7 @@ func (a *Airlock) steadyStateHandler(req *http.Request) *herrors.HTTPError {
 
 	logrus.WithFields(logrus.Fields{
 		"group": nodeIdentity.Group,
-		"uuid":  nodeIdentity.UUID,
+		"id":    nodeIdentity.ID,
 	}).Debug("steady-state confirmed")
 
 	return nil


### PR DESCRIPTION
This updates the protocol and server logic to relax the semantics
around a more generic "node ID".
While in general we prefer machine-bound UUIDs, some cluster managers
have other meanings of identifying and orchestrating nodes
(e.g. kubernetes node-names).