### PR TITLE
server: fix leaking connections

### DIFF
--- a/internal/server/airlock.go
+++ b/internal/server/airlock.go
@@ -107,6 +107,8 @@ func (a *Airlock) checkConsistency(ctx context.Context, group string, maxSlots u
 		}).Warn("consistency check, manager creation failed")
 		return
 	}
+	defer manager.Close()
+
 	semaphore, err := manager.FetchSemaphore(innerCtx)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
Hi, We encountered a problem running airlock for a longer period. Over time it stops responding and this error shows up in the logs. (multiple times)
"http: Accept error: accept tcp [::]:2222: accept4: too many open files; retrying in 1s"
In the container we noticed all open etcd connections:
> netstat -antp  
tcp        0      0 10.50.132.217:58864     10.50.31.46:2379        ESTABLISHED 1/airlock
tcp        0      0 10.50.132.217:53584     10.50.31.46:2379        ESTABLISHED 1/airlock
tcp        0      0 10.50.132.217:56712     10.50.31.46:2379        ESTABLISHED 1/airlock
tcp        0      0 10.50.132.217:34960     10.50.31.46:2379        ESTABLISHED 1/airlock
tcp        0      0 10.50.132.217:59586     10.50.31.46:2379        ESTABLISHED 1/airlock

This pull request fixes the issue
